### PR TITLE
add container option support to fix #4 copying in modal dialogs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.5.0",
-    "clipboard": "^1.5.12"
+    "clipboard": "^1.7.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.1.6",

--- a/granite-clipboard.html
+++ b/granite-clipboard.html
@@ -75,6 +75,13 @@ Typical usage:
             type: Boolean,
             value: false
           },
+          /**
+           * The focused element for cases when focus has been changed (e.g. in modal dialogs).
+           */
+          container: {
+            type: Object,
+            value: undefined
+          }
         },
 
         observers: [
@@ -105,7 +112,9 @@ Typical usage:
           this._allowedValues = ['copy','cut'];
         },
         attached: function() {
-          this.clipboard = new Clipboard(this.$.container);
+          this.clipboard = new Clipboard(this.$.container, {
+            container: this.container
+          });
           this.clipboard.on('success', this._onClipboardSuccess.bind(this));
         },
         detached: function() {


### PR DESCRIPTION
This adds support for new clipboard.js option "container" introduced in 1.7.0. By using the option, copying in modal dialogs works as expected.