### PR TITLE
add option to copy text content of an element

### DIFF
--- a/granite-clipboard.html
+++ b/granite-clipboard.html
@@ -41,7 +41,8 @@ Typical usage:
         <div 
             id="container" 
             data-clipboard-text$="[[text]]"
-            data-clipboard-action$="[[action]]">
+            data-clipboard-action$="[[action]]"
+            data-clipboard-target$="[[target]]">
           <slot></slot>
         </div>
     </template>
@@ -66,7 +67,14 @@ Typical usage:
             type: String,
             value: "copy",
             observer: "_onActionChange"
-          }, 
+          },
+          /**
+           * The selector of the element whose text content will be used for copying
+           * instead of the `text` property.
+           */
+          target: {
+            type: String
+          },
           _allowedValues: {
             type: Array
           },


### PR DESCRIPTION
This add the possibility of using text from an element instead of passing it by the `text` property. For me, this was the only way how to copy very long texts because it fails when using the attribute (see zenorocha/clipboard.js#442).