### PR TITLE
Checking clipboard before calling destroy()

### DIFF
--- a/granite-clipboard.html
+++ b/granite-clipboard.html
@@ -106,7 +106,9 @@ Typical usage:
         });
       },
       detached: function() {
-        this.clipboard.destroy();
+        if (this.clipboard) {
+          this.clipboard.destroy();
+        }
       }
     });
   </script>


### PR DESCRIPTION
I'm getting the following error when testing with WCT

`Test run ended in failure: Error thrown outside of test function: Cannot read property 'destroy' of undefined`
`HTMLElement.detached at /components/squadcast.fm/bower_components/granite-clipboard/granite-clipboard.html:109`

I tested the proposed contribution & it passes